### PR TITLE
Fixed checksum issues on arduino DUE

### DIFF
--- a/idDHT11.cpp
+++ b/idDHT11.cpp
@@ -4,7 +4,7 @@
 	PURPOSE: 	Interrupt driven Lib for DHT11 with Arduino.
 	LICENCE:	GPL v3 (http://www.gnu.org/licenses/gpl.html)
 	DATASHEET: http://www.micro4you.com/files/sensor/DHT11.pdf
-	
+
 	Based on DHT11 library: http://playground.arduino.cc/Main/DHT11Lib
 */
 
@@ -29,17 +29,17 @@ void idDHT11::init(int pin, int intNumber, void (*callback_wrapper) ()) {
 
 int idDHT11::acquire() {
 	if (state == STOPPED || state == ACQUIRED) {
-		
+
 		//set the state machine for interruptions analisis of the signal
 		state = RESPONSE;
-		
+
 		// EMPTY BUFFER and vars
 		for (int i=0; i< 5; i++) bits[i] = 0;
 		cnt = 7;
 		idx = 0;
 		hum = 0;
 		temp = 0;
-	
+
 		// REQUEST SAMPLE
 		pinMode(pin, OUTPUT);
 		digitalWrite(pin, LOW);
@@ -47,11 +47,11 @@ int idDHT11::acquire() {
 		digitalWrite(pin, HIGH);
 		delayMicroseconds(40);
 		pinMode(pin, INPUT);
-		
+
 		// Analize the data in an interrupt
 		us = micros();
 		attachInterrupt(intNumber,isrCallback_wrapper,FALLING);
-		
+
 		return IDDHTLIB_ACQUIRING;
 	} else
 		return IDDHTLIB_ERROR_ACQUIRING;
@@ -98,10 +98,12 @@ void idDHT11::isrCallback() {
 						if(idx++ == 4) {      // go to next byte, if whe have got 5 bytes stop.
 							detachInterrupt(intNumber);
 							// WRITE TO RIGHT VARS
-							// as bits[1] and bits[3] are allways zero they are omitted in formulas.
-							hum    = bits[0]; 
-							temp = bits[2]; 
-							uint8_t sum = bits[0] + bits[2];  
+							// Due to DHT11 resolution, bits[1] and bits[3] give useless information.
+							hum = bits[0];
+							temp = bits[2];
+							// Using arduino DUE a lot of checksum errors appeared.
+							// Modifying this line, this issue seems to stop.
+							uint8_t sum = bits[0] bits[1] + bits[2] + bits[3];
 							if (bits[4] != sum) {
 								status = IDDHTLIB_ERROR_CHECKSUM;
 								state = STOPPED;
@@ -160,10 +162,10 @@ double idDHT11::getDewPoint() {
 	double temp_ = (a * (double) temp) / (b + (double) temp) + log( (double) hum/100);
 	double Td = (b * temp_) / (a - temp_);
 	return Td;
-	
+
 }
 // dewPoint function NOAA
-// reference: http://wahiduddin.net/calc/density_algorithms.htm 
+// reference: http://wahiduddin.net/calc/density_algorithms.htm
 double idDHT11::getDewPointSlow() {
 	IDDHT11_CHECK_STATE;
 	double A0= 373.15/(273.15 + (double) temp);


### PR DESCRIPTION
Hi, niesteszeck! Using your code on an Arduino DUE I experienced several checksum errors (75% of all the measurements ended up in this error). This is because not always bits[1] and bits[3] are zero. 
However, DHT11 resolution makes these bytes useless.
I propose not using them in order to get humidity and temperature values, using them only to check if the transmission was satisfactory:
```c
// Due to DHT11 resolution, bits[1] and bits[3] give useless information.
hum = bits[0];
temp = bits[2];
// Using arduino DUE a lot of checksum errors appeared.
// Modifying this line, this issue seems to stop.
uint8_t sum = bits[0] bits[1] + bits[2] + bits[3];
```

Regards,
Román